### PR TITLE
Keep ipynb checkpoints, pycache, model file out of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ipynb_checkpoints/
+__pycache__/
+mask_rcnn_coco.h5


### PR DESCRIPTION
Keep these out of the repo:
- `.ipynb_checkpoints/`
- `__pycache__/`
- `mask_rcnn_coco.h5`