### PR TITLE
check the length of images in detect function

### DIFF
--- a/model.py
+++ b/model.py
@@ -2198,6 +2198,7 @@ class MaskRCNN():
         masks: [H, W, N] instance binary masks
         """
         assert self.mode == "inference", "Create model in inference mode."
+        assert len(images) == self.config.BATCH_SIZE, "len(images) must be equal to BATCH_SIZE"
 
         if verbose: 
             log("Processing {} images".format(len(images)))


### PR DESCRIPTION
check the length of images in detect function, to avoid error when len(images) != self.config.BATCH_SIZE