### PR TITLE
 support to save image with detection result

### DIFF
--- a/model.py
+++ b/model.py
@@ -2198,6 +2198,7 @@ class MaskRCNN():
         masks: [H, W, N] instance binary masks
         """
         assert self.mode == "inference", "Create model in inference mode."
+        assert len(images) == self.config.BATCH_SIZE, "len(images) must be equal to BATCH_SIZE"
 
         if verbose: 
             log("Processing {} images".format(len(images)))

--- a/visualize.py
+++ b/visualize.py
@@ -17,6 +17,8 @@ import matplotlib.patches as patches
 import matplotlib.lines as lines
 from matplotlib.patches import Polygon
 import IPython.display
+import os
+from PIL import Image, ImageDraw, ImageFont
 
 import utils
 
@@ -497,3 +499,97 @@ def display_weight_stats(model):
                 "{:+9.4f}".format(w.std()),
             ])
     display_table(table)
+
+
+def save_image(image, image_name, boxes, masks, class_ids, scores, class_names, filter_classs_names=None,
+               scores_thresh=0.1, save_dir=None, mode=0):
+    """
+        image: image array
+        image_name: image name
+        boxes: [num_instance, (y1, x1, y2, x2, class_id)] in image coordinates.
+        masks: [num_instances, height, width]
+        class_ids: [num_instances]
+        scores: confidence scores for each box
+        class_names: list of class names of the dataset
+        filter_classs_names: (optional) list of class names we want to draw
+        scores_thresh: (optional) threshold of confidence scores
+        save_dir: (optional) the path to store image
+        mode: (optional) select the result which you want
+                mode = 0 , save image with bbox,class_name,score and mask;
+                mode = 1 , save image with bbox,class_name and score;
+                mode = 2 , save image with class_name,score and mask;
+                mode = 3 , save mask with black background;
+    """
+    mode_list = [0, 1, 2, 3]
+    assert mode in mode_list, "mode's value should in mode_list %s" % str(mode_list)
+
+    if save_dir is None:
+        save_dir = os.path.join(os.getcwd(), "output")
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+
+    useful_mask_indices = []
+
+    N = boxes.shape[0]
+    if not N:
+        print("\n*** No instances in image %s to draw *** \n" % (image_name))
+        return
+    else:
+        assert boxes.shape[0] == masks.shape[-1] == class_ids.shape[0]
+
+    for i in range(N):
+        # filter
+        class_id = class_ids[i]
+        score = scores[i] if scores is not None else None
+        if score is None or score < scores_thresh:
+            continue
+
+        label = class_names[class_id]
+        if (filter_classs_names is not None) and (label not in filter_classs_names):
+            continue
+
+        if not np.any(boxes[i]):
+            # Skip this instance. Has no bbox. Likely lost in image cropping.
+            continue
+
+        useful_mask_indices.append(i)
+
+    if len(useful_mask_indices) == 0:
+        print("\n*** No instances in image %s to draw *** \n" % (image_name))
+        return
+
+    colors = random_colors(len(useful_mask_indices))
+
+    if mode != 3:
+        masked_image = image.astype(np.uint8).copy()
+    else:
+        masked_image = np.zeros(image.shape).astype(np.uint8)
+
+    if mode != 1:
+        for index, value in enumerate(useful_mask_indices):
+            masked_image = apply_mask(masked_image, masks[:, :, value], colors[index])
+
+    masked_image = Image.fromarray(masked_image)
+
+    if mode == 3:
+        masked_image.save(os.path.join(save_dir, '%s.jpg' % (image_name)))
+        return
+
+    draw = ImageDraw.Draw(masked_image)
+    colors = np.array(colors).astype(int) * 255
+
+    for index, value in enumerate(useful_mask_indices):
+        class_id = class_ids[value]
+        score = scores[value]
+        label = class_names[class_id]
+
+        y1, x1, y2, x2 = boxes[value]
+        if mode != 2:
+            color = tuple(colors[index])
+            draw.rectangle((x1, y1, x2, y2), outline=color)
+
+        # Label
+        font = ImageFont.truetype('/Library/Fonts/Arial.ttf', 15)
+        draw.text((x1, y1), "%s %f" % (label, score), (255, 255, 255), font)
+
+    masked_image.save(os.path.join(save_dir, '%s.jpg' % (image_name)))


### PR DESCRIPTION
        save_image(image, image_name, boxes, masks, class_ids, scores, class_names,                 filter_classs_names=None,
                       scores_thresh=0.1, save_dir=None, mode=0)
    
        image: image array
        image_name: image name
        boxes: [num_instance, (y1, x1, y2, x2, class_id)] in image coordinates.
        masks: [num_instances, height, width]
        class_ids: [num_instances]
        scores: confidence scores for each box
        class_names: list of class names of the dataset
        filter_classs_names: (optional) list of class names we want to draw
        scores_thresh: (optional) threshold of confidence scores
        save_dir: (optional) the path to store image
        mode: (optional) select the result which you want
                mode = 0 , save image with bbox,class_name,score and mask;
                mode = 1 , save image with bbox,class_name and score;
                mode = 2 , save image with class_name,score and mask;
                mode = 3 , save mask with black background;


demo code 

    image = skimage.io.imread(os.path.join(IMAGE_DIR,image_name))
    results = model.detect([image], verbose=1)
    r = results[0]
    visualize.save_image(image, image_name, r['rois'], r['masks'],
        r['class_ids'],r['scores'],coco_class_names,
        filter_classs_names=['bottle', 'wine glass'],scores_thresh=0.9,mode=0)