### PR TITLE
Update coco.py

### DIFF
--- a/coco.py
+++ b/coco.py
@@ -133,7 +133,7 @@ class CocoDataset(utils.Dataset):
                 path=os.path.join(image_dir, coco.imgs[i]['file_name']),
                 width=coco.imgs[i]["width"],
                 height=coco.imgs[i]["height"],
-                annotations=coco.loadAnns(coco.getAnnIds(imgIds=[i], iscrowd=False)))
+                annotations=coco.loadAnns(coco.getAnnIds(imgIds=[i],catIds=clase_ids, iscrowd=False)))
         if return_coco:
             return coco
 


### PR DESCRIPTION
When resetting class_ids to decide which classes should be involved in dataset, the annotations should also only load these classed.