### PR TITLE
Remove unnecessary function call from within a loop

### DIFF
--- a/model.py
+++ b/model.py
@@ -753,8 +753,8 @@ class DetectionLayer(KE.Layer):
     def call(self, inputs):
         def wrapper(rois, mrcnn_class, mrcnn_bbox, image_meta):
             detections_batch = []
+            _, _, window, _ = parse_image_meta(image_meta)
             for b in range(self.config.BATCH_SIZE):
-                _, _, window, _ = parse_image_meta(image_meta)
                 detections = refine_detections(
                     rois[b], mrcnn_class[b], mrcnn_bbox[b], window[b], self.config)
                 # Pad with zeros if detections < DETECTION_MAX_INSTANCES


### PR DESCRIPTION
Move line 757 above the loop. Shouldn't have important speed gains if any and only with a large batch size (I've only used 1 or 2 images per batch) but it doesn't seem like the patch should cause any regressions, so there's probably no harm in merging it.