### PR TITLE
Automatically download COCO image files and annotations, if requested

### DIFF
--- a/coco.py
+++ b/coco.py
@@ -64,6 +64,7 @@ DEFAULT_DATASET_YEAR = "2014"
 #  Configurations
 ############################################################
 
+
 class CocoConfig(Config):
     """Configuration for training on MS COCO.
     Derives from the base Config class and overrides values specific
@@ -101,7 +102,7 @@ class CocoDataset(utils.Dataset):
         auto_download: Automatically download and unzip MS-COCO images and annotations
         """
 
-        if auto_download == True:
+        if auto_download is True:
             self.auto_download(dataset_dir, subset, year)
 
         coco = COCO("{}/annotations/instances_{}{}.json".format(dataset_dir, subset, year))
@@ -160,7 +161,7 @@ class CocoDataset(utils.Dataset):
             imgDir = "{}/{}{}".format(dataDir, dataType, dataYear)
             imgZipFile = "{}/{}{}.zip".format(dataDir, dataType, dataYear)
             imgURL = "http://images.cocodataset.org/zips/{}{}.zip".format(dataType, dataYear)
-        # print ("Image paths:"); print (imgDir); print (imgZipFile); print (imgURL)
+        # print("Image paths:"); print(imgDir); print(imgZipFile); print(imgURL)
 
         # Create main folder if it doesn't exist yet
         if not os.path.exists(dataDir):
@@ -169,15 +170,15 @@ class CocoDataset(utils.Dataset):
         # Download images if not available locally
         if not os.path.exists(imgDir):
             os.makedirs(imgDir)
-            print ("Downloading images to " + imgZipFile + " ...")
+            print("Downloading images to " + imgZipFile + " ...")
             with urllib.request.urlopen(imgURL) as resp, open(imgZipFile, 'wb') as out:
                 shutil.copyfileobj(resp, out)
-            print ("... done downloading.")
-            print ("Unzipping " + imgZipFile)
-            with zipfile.ZipFile(imgZipFile,"r") as zip_ref:
+            print("... done downloading.")
+            print("Unzipping " + imgZipFile)
+            with zipfile.ZipFile(imgZipFile, "r") as zip_ref:
                 zip_ref.extractall(dataDir)
-            print ("... done unzipping")
-        print ("Will use images in " + imgDir)
+            print("... done unzipping")
+        print("Will use images in " + imgDir)
 
         # Setup annotations data paths
         annDir = "{}/annotations".format(dataDir)
@@ -196,22 +197,22 @@ class CocoDataset(utils.Dataset):
             annFile = "{}/instances_{}{}.json".format(annDir, dataType, dataYear)
             annURL = "http://images.cocodataset.org/annotations/annotations_trainval{}.zip".format(dataYear)
             unZipDir = dataDir
-        # print ("Annotations paths:"); print (annDir); print (annFile); print (annZipFile); print (annURL)
+        # print("Annotations paths:"); print(annDir); print(annFile); print(annZipFile); print(annURL)
 
         # Download annotations if not available locally
         if not os.path.exists(annDir):
             os.makedirs(annDir)
         if not os.path.exists(annFile):
             if not os.path.exists(annZipFile):
-                print ("Downloading zipped annotations to " + annZipFile + " ...")
+                print("Downloading zipped annotations to " + annZipFile + " ...")
                 with urllib.request.urlopen(annURL) as resp, open(annZipFile, 'wb') as out:
                     shutil.copyfileobj(resp, out)
-                print ("... done downloading.")
-            print ("Unzipping " + annZipFile)
-            with zipfile.ZipFile(annZipFile,"r") as zip_ref:
+                print("... done downloading.")
+            print("Unzipping " + annZipFile)
+            with zipfile.ZipFile(annZipFile, "r") as zip_ref:
                 zip_ref.extractall(unZipDir)
-            print ("... done unzipping")
-        print ("Will use annotations in " + annFile)
+            print("... done unzipping")
+        print("Will use annotations in " + annFile)
 
     def load_mask(self, image_id):
         """Load instance masks for the given image.

--- a/coco.py
+++ b/coco.py
@@ -100,6 +100,7 @@ class CocoDataset(utils.Dataset):
         return_coco: If True, returns the COCO object.
         auto_download: Automatically download and unzip MS-COCO images and annotations
         """
+
         if auto_download == True:
             self.auto_download(dataset_dir, subset, year)
 
@@ -159,7 +160,7 @@ class CocoDataset(utils.Dataset):
             imgDir = "{}/{}{}".format(dataDir, dataType, dataYear)
             imgZipFile = "{}/{}{}.zip".format(dataDir, dataType, dataYear)
             imgURL = "http://images.cocodataset.org/zips/{}{}.zip".format(dataType, dataYear)
-        print ("Image paths:"); print (imgDir); print (imgZipFile); print (imgURL)
+        # print ("Image paths:"); print (imgDir); print (imgZipFile); print (imgURL)
 
         # Create main folder if it doesn't exist yet
         if not os.path.exists(dataDir):
@@ -176,7 +177,7 @@ class CocoDataset(utils.Dataset):
             with zipfile.ZipFile(imgZipFile,"r") as zip_ref:
                 zip_ref.extractall(dataDir)
             print ("... done unzipping")
-        # print ("Will use images in " + imgDir)
+        print ("Will use images in " + imgDir)
 
         # Setup annotations data paths
         annDir = "{}/annotations".format(dataDir)
@@ -418,8 +419,9 @@ if __name__ == '__main__':
                         help='Images to use for evaluation (default=500)')
     parser.add_argument('--download', required=False,
                         default=False,
-                        metavar="<auto download>",
-                        help='Automatically download and unzip MS-COCO files (default=False)')
+                        metavar="<True|False>",
+                        help='Automatically download and unzip MS-COCO files (default=False)',
+                        type=bool)
     args = parser.parse_args()
     print("Command: ", args.command)
     print("Model: ", args.model)
@@ -470,13 +472,13 @@ if __name__ == '__main__':
         # Training dataset. Use the training set and 35K from the
         # validation set, as as in the Mask RCNN paper.
         dataset_train = CocoDataset()
-        dataset_train.load_coco(args.dataset, "train")
-        dataset_train.load_coco(args.dataset, "valminusminival")
+        dataset_train.load_coco(args.dataset, "train", year=args.year, auto_download=args.download)
+        dataset_train.load_coco(args.dataset, "valminusminival", year=args.year, auto_download=args.download)
         dataset_train.prepare()
 
         # Validation dataset
         dataset_val = CocoDataset()
-        dataset_val.load_coco(args.dataset, "minival")
+        dataset_val.load_coco(args.dataset, "minival", year=args.year, auto_download=args.download)
         dataset_val.prepare()
 
         # *** This training schedule is an example. Update to your needs ***
@@ -507,7 +509,7 @@ if __name__ == '__main__':
     elif args.command == "evaluate":
         # Validation dataset
         dataset_val = CocoDataset()
-        coco = dataset_val.load_coco(args.dataset, "minival", return_coco=True)
+        coco = dataset_val.load_coco(args.dataset, "minival", year=args.year, return_coco=True, auto_download=args.download)
         dataset_val.prepare()
         print("Running COCO evaluation on {} images.".format(args.limit))
         evaluate_coco(model, dataset_val, coco, "bbox", limit=int(args.limit))


### PR DESCRIPTION
If requested, automatically download annotations and image files for the COCO dataset, including the "minival" and "valminusminival" annotations provided by Ross Girshick on Dropbox. Tested with `inspect_model.ipynb` and on the command line with `python coco.py evaluate --dataset=cocodataset --model=mask_rcnn_coco.h5 --download=True` on a machine without the dataset. The latter populates the folder `cocodataset` with the correct image data and annotation files.