### PR TITLE
On Windows, always run generator on main thread (Keras 2.1.2+ only!)

### DIFF
--- a/model.py
+++ b/model.py
@@ -2189,6 +2189,11 @@ class MaskRCNN():
         self.set_trainable(layers)
         self.compile(learning_rate, self.config.LEARNING_MOMENTUM)
 
+        if os.name is 'nt':
+            workers = 0
+        else:
+            workers = max(self.config.BATCH_SIZE // 2, 2)
+
         self.keras_model.fit_generator(
             train_generator,
             initial_epoch=self.epoch,
@@ -2198,7 +2203,7 @@ class MaskRCNN():
             validation_data=next(val_generator),
             validation_steps=self.config.VALIDATION_STEPS,
             max_queue_size=100,
-            workers=max(self.config.BATCH_SIZE // 2, 2),
+            workers=workers,
             use_multiprocessing=True,
         )
         self.epoch = max(self.epoch, epochs)


### PR DESCRIPTION
On Windows, always run the generator on the main thread. This fix only works with keras 2.1.2+. For  all previous versions, on Windows, you will get the following whenever calling `fit_generator`:

``` python
StopIteration                             Traceback (most recent call last)
<ipython-input-9-2101606c7d8e> in <module>()
      6             learning_rate=config.LEARNING_RATE,
      7             epochs=1,
----> 8             layers='heads')

E:\repos\Mask_RCNN-fork-auto-coco\model.py in train(self, train_dataset, val_dataset, learning_rate, epochs, layers)
   2205             max_queue_size=100,
   2206             workers=workers,
-> 2207             use_multiprocessing=True,
   2208         )
   2209         self.epoch = max(self.epoch, epochs)

e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36maskrcnncpukerasold\lib\site-packages\keras\legacy\interfaces.py in wrapper(*args, **kwargs)
     85                 warnings.warn('Update your `' + object_name +
     86                               '` call to the Keras 2 API: ' + signature, stacklevel=2)
---> 87             return func(*args, **kwargs)
     88         wrapper._original_function = func
     89         return wrapper

e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36maskrcnncpukerasold\lib\site-packages\keras\engine\training.py in fit_generator(self, generator, steps_per_epoch, epochs, verbose, callbacks, validation_data, validation_steps, class_weight, max_queue_size, workers, use_multiprocessing, shuffle, initial_epoch)
   2081                 batch_index = 0
   2082                 while steps_done < steps_per_epoch:
-> 2083                     generator_output = next(output_generator)
   2084 
   2085                     if not hasattr(generator_output, '__len__'):

e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36maskrcnncpukerasold\lib\site-packages\keras\utils\data_utils.py in get(self)
    708                 all_finished = all([not thread.is_alive() for thread in self._threads])
    709                 if all_finished and self.queue.empty():
--> 710                     raise StopIteration()
    711                 else:
    712                     time.sleep(self.wait_time)

StopIteration: 
```

Consequently, I recommend merging this fix  **only** if you are willing to bump `Mask_RCNN`'s Keras version requirement to 2.1.2 or later. You may want to update `README.md` to reflect that as well.