### PR TITLE
updated line 531 for Python 3.6

### DIFF
--- a/model.py
+++ b/model.py
@@ -528,7 +528,7 @@ def detection_targets_graph(proposals, gt_class_ids, gt_boxes, gt_masks, config)
     positive_indices = tf.random_shuffle(positive_indices)[:positive_count]
     positive_count = tf.shape(positive_indices)[0]
     # Negative ROIs. Add enough to maintain positive:negative ratio.
-    r = 1.0 / config.ROI_POSITIVE_RATIO
+    r = 1.0 / tf.cast(config.ROI_POSITIVE_RATIO,tf.float32) # for Python 3.6
     negative_count = tf.cast(r * tf.cast(positive_count, tf.float32), tf.int32) - positive_count
     negative_indices = tf.random_shuffle(negative_indices)[:negative_count]
     # Gather selected ROIs


### PR DESCRIPTION
With Python 3.6.3 [GCC 7.2.0], tested in Google Colaboratory,  there is an issue in model.py (see below). The same issue does not appear with Python 3.5 (Ubunut 16.04 LTS stock). 

Here I propose to add tf.cast to ROI_POSITIVE_RATIO to convert to float32 to avoid this issue. 

line 531: r = 1.0 / tf.cast(config.ROI_POSITIVE_RATIO,tf.float32) # for Python 3.6

This proposed change is tested in 3.5 and 3.6.


/content/model.py in detection_targets_graph(proposals, gt_class_ids, gt_boxes, gt_masks, config)
529 positive_count = tf.shape(positive_indices)[0]
530 # Negative ROIs. Add enough to maintain positive:negative ratio.
--> 531 r = 1.0 / config.ROI_POSITIVE_RATIO
532 negative_count = tf.cast(r * tf.cast(positive_count, tf.float32), tf.int32) - positive_count
533 negative_indices = tf.random_shuffle(negative_indices)[:negative_count]

TypeError: unsupported operand type(s) for /: 'Tensor' and 'float'