### PR TITLE
Refactor compute AP using mask instead of bounding boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .ipynb_checkpoints/
 __pycache__/
 mask_rcnn_coco.h5
+.idea/
+

--- a/train_shapes.ipynb
+++ b/train_shapes.ipynb
@@ -994,8 +994,8 @@
     "    r = results[0]\n",
     "    # Compute AP\n",
     "    AP, precisions, recalls, overlaps =\\\n",
-    "        utils.compute_ap(gt_bbox, gt_class_id,\n",
-    "                         r[\"rois\"], r[\"class_ids\"], r[\"scores\"])\n",
+    "        utils.compute_ap(gt_bbox, gt_class_id, gt_mask,\n",
+    "                         r[\"rois\"], r[\"class_ids\"], r[\"scores\"], r['masks'])\n",
     "    APs.append(AP)\n",
     "    \n",
     "print(\"mAP: \", np.mean(APs))"

--- a/utils.py
+++ b/utils.py
@@ -92,6 +92,23 @@ def compute_overlaps(boxes1, boxes2):
         overlaps[:, i] = compute_iou(box2, boxes1, area2[i], area1)
     return overlaps
 
+def compute_overlaps_masks(masks1, masks2):
+    '''Computes IoU overlaps between two sets of masks.
+    masks1, masks2: [Height, Width, instances]
+    '''
+    # flatten masks
+    masks1 = np.reshape(masks1 > .5, (-1, masks1.shape[-1])).astype(np.float32)
+    masks2 = np.reshape(masks2 > .5, (-1, masks2.shape[-1])).astype(np.float32)
+    area1 = np.sum(masks1, axis=0)
+    area2 = np.sum(masks2, axis=0)
+
+    # intersections and union
+    intersections = np.dot(masks1.T, masks2)
+    union = area1[:, None] + area2[None, :] - intersections
+    overlaps = intersections / union
+
+    return overlaps
+
 
 def non_max_suppression(boxes, scores, threshold):
     """Performs non-maximum supression and returns indicies of kept boxes.

--- a/utils.py
+++ b/utils.py
@@ -92,6 +92,7 @@ def compute_overlaps(boxes1, boxes2):
         overlaps[:, i] = compute_iou(box2, boxes1, area2[i], area1)
     return overlaps
 
+
 def compute_overlaps_masks(masks1, masks2):
     '''Computes IoU overlaps between two sets of masks.
     masks1, masks2: [Height, Width, instances]
@@ -288,6 +289,7 @@ class Dataset(object):
         TODO: class map is not supported yet. When done, it should handle mapping
               classes from different datasets to the same class ID.
         """
+
         def clean_name(name):
             """Returns a shorter version of object names for cleaner display."""
             return ",".join(name.split(",")[:1])
@@ -582,8 +584,8 @@ def trim_zeros(x):
     return x[~np.all(x == 0, axis=1)]
 
 
-def compute_ap(gt_boxes, gt_class_ids,
-               pred_boxes, pred_class_ids, pred_scores,
+def compute_ap(gt_boxes, gt_class_ids, gt_masks,
+               pred_boxes, pred_class_ids, pred_scores, pred_masks,
                iou_threshold=0.5):
     """Compute Average Precision at a set IoU threshold (default 0.5).
 
@@ -596,15 +598,17 @@ def compute_ap(gt_boxes, gt_class_ids,
     # Trim zero padding and sort predictions by score from high to low
     # TODO: cleaner to do zero unpadding upstream
     gt_boxes = trim_zeros(gt_boxes)
+    gt_masks = gt_masks[..., :gt_boxes.shape[0]]
     pred_boxes = trim_zeros(pred_boxes)
     pred_scores = pred_scores[:pred_boxes.shape[0]]
     indices = np.argsort(pred_scores)[::-1]
     pred_boxes = pred_boxes[indices]
     pred_class_ids = pred_class_ids[indices]
     pred_scores = pred_scores[indices]
+    pred_masks = pred_masks[..., indices]
 
-    # Compute IoU overlaps [pred_boxes, gt_boxes]
-    overlaps = compute_overlaps(pred_boxes, gt_boxes)
+    # Compute IoU overlaps [pred_masks, gt_masks]
+    overlaps = compute_overlaps_masks(pred_masks, gt_masks)
 
     # Loop through ground truth boxes and find matching predictions
     match_count = 0


### PR DESCRIPTION
In original paper, the model is evaluated by mask AP. In this pull request, overlapping computation with masks was implemented and replaced the original steps using bounding boxes. 