### PR TITLE
fix nan rpn bbox loss issue

### DIFF
--- a/model.py
+++ b/model.py
@@ -1205,7 +1205,7 @@ def load_image_gt(dataset, config, image_id, augment=False,
 
     # Note that some boxes might be all zeros if the corresponding mask got cropped out.
     # and here is to filter them out
-    _idx = np.sum(np.where(mask > 0, 1, 0), axis=(0, 1)) >= 0
+    _idx = np.sum(mask, axis=(0, 1)) > 0
     mask = mask[:, :, _idx]
 
     # Bounding boxes. Note that some boxes might be all zeros

--- a/model.py
+++ b/model.py
@@ -1203,6 +1203,11 @@ def load_image_gt(dataset, config, image_id, augment=False,
             image = np.fliplr(image)
             mask = np.fliplr(mask)
 
+    # Note that some boxes might be all zeros if the corresponding mask got cropped out.
+    # and here is to filter them out
+    _idx = np.sum(np.where(mask > 0, 1, 0), axis=(0, 1)) >= 0
+    mask = mask[:, :, _idx]
+
     # Bounding boxes. Note that some boxes might be all zeros
     # if the corresponding mask got cropped out.
     # bbox: [num_instances, (y1, x1, y2, x2)]


### PR DESCRIPTION
hopefully fix some of the cases in #159

The cropping will cause boxes to be zero thus the division zero issue as reported in #159. This fix at lease fix the same issue I had. 