### PR TITLE
Headline typo fix in README.md

### DIFF
--- a/samples/balloon/README.md
+++ b/samples/balloon/README.md
@@ -1,4 +1,4 @@
-# Color Spash Example
+# Color Splash Example
 
 This is an example showing the use of Mask RCNN in a real application.
 We train the model to detect balloons only, and then we use the generated 


### PR DESCRIPTION
Fixes the typo in the headline of the README.md file. 
"Spash" should be "Splash"