### PR TITLE
Fix color_splash to handle when no masks detected in model

### DIFF
--- a/samples/balloon/balloon.py
+++ b/samples/balloon/balloon.py
@@ -207,7 +207,7 @@ def color_splash(image, mask):
     # We're treating all instances as one, so collapse the mask into one layer
     mask = (np.sum(mask, -1, keepdims=True) >= 1)
     # Copy color pixels from the original color image where mask is set
-    if mask.shape[0] > 0 and mask.shape[0] == gray.shape[0]:
+    if mask.shape[0] == gray.shape[0]:
         splash = np.where(mask, image, gray).astype(np.uint8)
     else:
         splash = gray.astype(np.uint8)

--- a/samples/balloon/balloon.py
+++ b/samples/balloon/balloon.py
@@ -207,10 +207,10 @@ def color_splash(image, mask):
     # We're treating all instances as one, so collapse the mask into one layer
     mask = (np.sum(mask, -1, keepdims=True) >= 1)
     # Copy color pixels from the original color image where mask is set
-    if mask.shape[0] > 0:
+    if mask.shape[0] > 0 and mask.shape[0] == gray.shape[0]:
         splash = np.where(mask, image, gray).astype(np.uint8)
     else:
-        splash = gray
+        splash = gray.astype(np.uint8)
     return splash
 
 


### PR DESCRIPTION
For images where the model does not detect any labels it still appears to return a single mask of shape (28, 28, 1) containing all False values. The if/else statement in the **color_splash** function does not handle this edge case properly so when it is encountered the np.where operation fails with the error:

ValueError: operands could not be broadcast together with shapes (28, 28, 1) (<gray.shape>) (<image.shape>)

This PR fixes this by modifying the if statement to ensure that if there is a mask it has the same shape as the grayscale image. It also fixes the else branch to convert the grayscale image to uint8 as is done in the if branch. If this is not done then the following error is raised when calling imsave:

ValueError: Images of type float must be between -1 and 1.