### PR TITLE
Fix ROOT_DIR path and autodownload arg parse

### DIFF
--- a/samples/coco/coco.py
+++ b/samples/coco/coco.py
@@ -48,7 +48,7 @@ import urllib.request
 import shutil
 
 # Root directory of the project
-ROOT_DIR = os.path.abspath("../../")
+ROOT_DIR = os.getcwd()
 
 # Import Mask RCNN
 sys.path.append(ROOT_DIR)  # To find local version of the library
@@ -425,9 +425,7 @@ if __name__ == '__main__':
                         help='Images to use for evaluation (default=500)')
     parser.add_argument('--download', required=False,
                         default=False,
-                        metavar="<True|False>",
-                        help='Automatically download and unzip MS-COCO files (default=False)',
-                        type=bool)
+                        action='store_true')
     args = parser.parse_args()
     print("Command: ", args.command)
     print("Model: ", args.model)


### PR DESCRIPTION
This commit changes the ROOT_DIR from `../../` for the current working directory, which is the intended use of it after all. Therefore, the `DEFAULT_LOGS_DIR` will be placed under the project directory root, and not in `$HOME/logs` when the `--logs` argument is not provided in command line execution.

Now to call training, you need so simply supply the `--autodownload` flag. Before, the flag was passed in as a string and was automatically set to true because when you bool(<string>) it is always true. In this case, we can interpret the autodownload flag as a boolean directly when it is supplied.

Additionally, we no longer need to explicitly set the `PYTHONPATH` from command line when we train, and the current command line expressions that are defined in the readme still work, we simply removed a step and provide additional clarity on which directory will always be the project root.