### PR TITLE
Bug fix: create log_dir

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2235,6 +2235,10 @@ class MaskRCNN():
         self.log_dir = os.path.join(self.model_dir, "{}{:%Y%m%dT%H%M}".format(
             self.config.NAME.lower(), now))
 
+        # Create log_dir if not exists
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+
         # Path to save after each epoch. Include placeholders that get filled by Keras.
         self.checkpoint_path = os.path.join(self.log_dir, "mask_rcnn_{}_*epoch*.h5".format(
             self.config.NAME.lower()))


### PR DESCRIPTION
As I described in [issue#544](https://github.com/matterport/Mask_RCNN/issues/544),

My very personal opinion is that : "**Keras.callbacks**" should simply behave in a "**Plug&Play**" style.
Thus it is natural that if we unplug a "callback", the rest of the system should run without any problem.

The current codebase( I have to say it's great and amazing already) did not consider the situation when people do not use "TensorBoard", so that the log dir would not be created(it's now created by the "**tf.summary.FileWriter**" inside "**keras.callbacks.TensorBoard**") and would result in the "Directory not found" error when saving "**ModelCheckpoint**"

And the solution is pretty straight forward, just check the "**log_dir**" and create it if not exists