### PR TITLE
Few dependencies fixes, and bug fixes.

### DIFF
--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -17,7 +17,7 @@ import scipy
 import skimage.color
 import skimage.io
 import skimage.transform
-import urllib.request
+import urllib
 import shutil
 import warnings
 
@@ -849,7 +849,7 @@ def download_trained_weights(coco_model_path, verbose=1):
     """
     if verbose > 0:
         print("Downloading pretrained model to " + coco_model_path + " ...")
-    with urllib.request.urlopen(COCO_MODEL_URL) as resp, open(coco_model_path, 'wb') as out:
+    with urllib.urlretrieve(COCO_MODEL_URL) as resp, open(coco_model_path, 'wb') as out:
         shutil.copyfileobj(resp, out)
     if verbose > 0:
         print("... done downloading pretrained model!")

--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -867,8 +867,8 @@ def norm_boxes(boxes, shape):
         [N, (y1, x1, y2, x2)] in normalized coordinates
     """
     h, w = shape
-    scale = np.array([h - 1, w - 1, h - 1, w - 1])
-    shift = np.array([0, 0, 1, 1])
+    scale = np.array([h - 1, w - 1, h - 1, w - 1]).astype(np.float32)
+    shift = np.array([0, 0, 1, 1]).astype(np.float32)
     return np.divide((boxes - shift), scale).astype(np.float32)
 
 


### PR DESCRIPTION
Urllib requests package is deprecated. Hence changed it to urllib.retreive().

Fixed norm_boxes() in utils.py , which was returning a zero-matrix on divide. So used asfloat(np.float32)