### PR TITLE
Corrected a dependency comment

### DIFF
--- a/samples/coco/coco.py
+++ b/samples/coco/coco.py
@@ -31,7 +31,7 @@ import os
 import sys
 import time
 import numpy as np
-import imgaug  # https://github.com/aleju/imgaug (pip3 install imageaug)
+import imgaug  # https://github.com/aleju/imgaug (pip3 install imgaug)
 
 # Download and install the Python COCO tools from https://github.com/waleedka/coco
 # That's a fork from the original https://github.com/pdollar/coco with a bug


### PR DESCRIPTION
There is a dependency for the coco dataset when using the demo.ipynb file.  This dependency is the imageaug repo on GitHub.  It is installed by calling "pip3 install imgaug", not "pip3 install imageaug" as the original comment specified.  I spent some time figuring out what went wrong and corrected this comment.  