### PR TITLE
bug fix: un-excepted creation(issue#545) is now removed

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2251,12 +2251,12 @@ class MaskRCNN():
                 self.epoch = int(m.group(6)) - 1 + 1
                 print('Re-starting from epoch %d' % self.epoch)
 
-        # Directory for training logs
-        self.log_dir = os.path.join(self.model_dir, "{}{:%Y%m%dT%H%M}".format(
-            self.config.NAME.lower(), now))
+        # Directory for training logs:  Init self.log_dir for only once to avoid duplicate creation
+        if not hasattr(self, "log_dir"):
+            self.log_dir = os.path.join(self.model_dir, "{}{:%Y%m%dT%H%M}".format(self.config.NAME.lower(), now))
 
-        # Create log_dir if not exists
-        if not os.path.exists(self.log_dir):
+        # Create log_dir if not existed
+        if not os.path.exists(self.log_dir) and self.mode == "training":
             os.makedirs(self.log_dir)
 
         # Path to save after each epoch. Include placeholders that get filled by Keras.


### PR DESCRIPTION
Hi @waleedka , 
I found some other problems related to my first PR these days when playing around with this repo.

Two main problems of the last version:

1. we should not create log_dir when "**dectect**".

2. Since the method "**set_log_dir**" is used at 2 places: "**\_\_init\_\_**" and "**load_weights**", sometimes we lunch the training at the end of a minute let's say 201806061530, two folders: "201806061530" and "201806061531" may be created.

This PR fixed problems described above, thank you.