### PR TITLE
Updating future potentially deprecated code

### DIFF
--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -17,7 +17,7 @@ import scipy
 import skimage.color
 import skimage.io
 import skimage.transform
-import urllib.request
+import urllib
 import shutil
 import warnings
 
@@ -853,7 +853,7 @@ def download_trained_weights(coco_model_path, verbose=1):
     """
     if verbose > 0:
         print("Downloading pretrained model to " + coco_model_path + " ...")
-    with urllib.request.urlopen(COCO_MODEL_URL) as resp, open(coco_model_path, 'wb') as out:
+    with urllib.urlopen(COCO_MODEL_URL) as resp, open(coco_model_path, 'wb') as out:
         shutil.copyfileobj(resp, out)
     if verbose > 0:
         print("... done downloading pretrained model!")


### PR DESCRIPTION
Documentation says urllib.request "might become deprecated at some point in the future".

IMHO, it's better to provide examples that do not make users rely on API that has this label.