### PR TITLE
Fixed warnings resulting from calls to skimage.transform.resize

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1437,14 +1437,14 @@ def build_detection_targets(rpn_rois, gt_class_ids, gt_boxes, gt_masks, config):
             # Resize mini mask to size of GT box
             placeholder[gt_y1:gt_y2, gt_x1:gt_x2] = \
                 np.round(skimage.transform.resize(
-                    class_mask, (gt_h, gt_w), order=1, mode="constant")).astype(bool)
+                    class_mask, (gt_h, gt_w), order=1, mode="constant", anti_aliasing=True)).astype(bool)
             # Place the mini batch in the placeholder
             class_mask = placeholder
 
         # Pick part of the mask and resize it
         y1, x1, y2, x2 = rois[i].astype(np.int32)
         m = class_mask[y1:y2, x1:x2]
-        mask = skimage.transform.resize(m, config.MASK_SHAPE, order=1, mode="constant")
+        mask = skimage.transform.resize(m, config.MASK_SHAPE, order=1, mode="constant", anti_aliasing=True)
         masks[i, :, :, class_id] = mask
 
     return rois, roi_gt_class_ids, bboxes, masks
@@ -2094,7 +2094,7 @@ class MaskRCNN():
         exlude: list of layer names to excluce
         """
         import h5py
-        from keras.engine import topology
+        from keras.engine import saving
 
         if exclude:
             by_name = True
@@ -2116,9 +2116,9 @@ class MaskRCNN():
             layers = filter(lambda l: l.name not in exclude, layers)
 
         if by_name:
-            topology.load_weights_from_hdf5_group_by_name(f, layers)
+            saving.load_weights_from_hdf5_group_by_name(f, layers)
         else:
-            topology.load_weights_from_hdf5_group(f, layers)
+            saving.load_weights_from_hdf5_group(f, layers)
         if hasattr(f, 'close'):
             f.close()
 

--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -454,7 +454,7 @@ def resize_image(image, min_dim=None, max_dim=None, min_scale=None, mode="square
     if scale != 1:
         image = skimage.transform.resize(
             image, (round(h * scale), round(w * scale)),
-            order=1, mode="constant", preserve_range=True)
+            order=1, mode="constant", preserve_range=True, anti_aliasing=True)
 
     # Need padding or cropping?
     if mode == "square":
@@ -538,7 +538,7 @@ def minimize_mask(bbox, mask, mini_shape):
         if m.size == 0:
             raise Exception("Invalid bounding box with area of zero")
         # Resize with bilinear interpolation
-        m = skimage.transform.resize(m, mini_shape, order=1, mode="constant")
+        m = skimage.transform.resize(m, mini_shape, order=1, mode="constant", anti_aliasing=True)
         mini_mask[:, :, i] = np.around(m).astype(np.bool)
     return mini_mask
 
@@ -556,7 +556,7 @@ def expand_mask(bbox, mini_mask, image_shape):
         h = y2 - y1
         w = x2 - x1
         # Resize with bilinear interpolation
-        m = skimage.transform.resize(m, (h, w), order=1, mode="constant")
+        m = skimage.transform.resize(m, (h, w), order=1, mode="constant", anti_aliasing=True)
         mask[y1:y2, x1:x2, i] = np.around(m).astype(np.bool)
     return mask
 
@@ -576,7 +576,7 @@ def unmold_mask(mask, bbox, image_shape):
     """
     threshold = 0.5
     y1, x1, y2, x2 = bbox
-    mask = skimage.transform.resize(mask, (y2 - y1, x2 - x1), order=1, mode="constant")
+    mask = skimage.transform.resize(mask, (y2 - y1, x2 - x1), order=1, mode="constant", anti_aliasing=True)
     mask = np.where(mask >= threshold, 1, 0).astype(np.bool)
 
     # Put the mask in the right location.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
+tensorflow-gpu
+tensorflow
+keras
 numpy
 scipy
 Pillow
 cython
 matplotlib
 scikit-image
-tensorflow>=1.3.0
-keras>=2.0.8
 opencv-python
 h5py
 imgaug
 IPython[all]
+git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI


### PR DESCRIPTION
Calls to skimage.transform.resize result in the warning "Anti-aliasing will be enabled by default in skimage ...". Therefore, the parameter anti_aliasing=True was added to each call of skimage.transform.resize.