### PR TITLE
bug fix: the output_shape of roi_gt_class_ids is incorrect

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -670,7 +670,7 @@ class DetectionTargetLayer(KE.Layer):
     def compute_output_shape(self, input_shape):
         return [
             (None, self.config.TRAIN_ROIS_PER_IMAGE, 4),  # rois
-            (None, 1),  # class_ids
+            (None, self.config.TRAIN_ROIS_PER_IMAGE),  # class_ids
             (None, self.config.TRAIN_ROIS_PER_IMAGE, 4),  # deltas
             (None, self.config.TRAIN_ROIS_PER_IMAGE, self.config.MASK_SHAPE[0],
              self.config.MASK_SHAPE[1])  # masks


### PR DESCRIPTION
when trying to add online hard example mining, I find the output shape of roi_gt_class_ids is not correct and the code can't run. 