### PR TITLE
Fix for UserWarning on anti-aliasing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 Pillow
 cython
 matplotlib
-scikit-image
+scikit-image==0.13.1
 tensorflow>=1.3.0
 keras>=2.0.8
 opencv-python


### PR DESCRIPTION
The following modification made to **requirements.txt** removes the following user warning encountered during training. 
`UserWarning: Anti-aliasing will be enabled by default in skimage 0.15 to avoid aliasing artifacts when down-sampling images. warn("Anti-aliasing will be enabled by default in skimage 0.15 to " class_ids----------->`

**Rationale:** Minimizes compiler verbosity in terminal and makes epoch training indicators more obvious for effective debugging. 