### PR TITLE
Weight='last' not working (fixed) and creating unnecessary log directories while retraining (fixed)

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2283,7 +2283,6 @@ class MaskRCNN():
             self.config.NAME.lower()))
         self.checkpoint_path = self.checkpoint_path.replace(
             "*epoch*", "{epoch:04d}")
-        print('the log_dir and checkpoint path is ', self.log_dir, self.checkpoint_path)
 
     def train(self, train_dataset, val_dataset, learning_rate, epochs, layers,
               augmentation=None, custom_callbacks=None, no_augmentation_sources=None):

--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1841,7 +1841,7 @@ class MaskRCNN():
         self.mode = mode
         self.config = config
         self.model_dir = model_dir
-        self.set_log_dir()
+        # self.set_log_dir()
         self.keras_model = self.build(mode=mode, config=config)
 
     def build(self, mode, config):
@@ -2283,6 +2283,7 @@ class MaskRCNN():
             self.config.NAME.lower()))
         self.checkpoint_path = self.checkpoint_path.replace(
             "*epoch*", "{epoch:04d}")
+        print('the log_dir and checkpoint path is ', self.log_dir, self.checkpoint_path)
 
     def train(self, train_dataset, val_dataset, learning_rate, epochs, layers,
               augmentation=None, custom_callbacks=None, no_augmentation_sources=None):


### PR DESCRIPTION
While trying to retrain the model using `weight='last'` argument, the existing code does not work as new log directory inside `logs` folder is created because of `self.set_log_dir()` in the `MaskRcnn` constructor. This creates a new log directory before checking for the `weight` argument which creates two problems:
1. For the `weight='last'` option because the directory returned by `model.find_last()` would be the newly created empty log directory instead of the actual last trained directory which  has all the required checkpoints. 
2. Instead of `weight='last'` if we give specific path to the checkpoint file like: `weight=path/to/existing/weight.h5` to start the training from the given checkpoint, an unnecessary new log directory is created, before continuing with the required checkpoint directory. 
Both problems are fixed by removing the `self.set_log_dir()` from the `MaskRcnn` constructor inside `model.py`.