### PR TITLE
Make pre_nms_limit configurable

### DIFF
--- a/mrcnn/config.py
+++ b/mrcnn/config.py
@@ -90,6 +90,9 @@ class Config(object):
 
     # How many anchors per image to use for RPN training
     RPN_TRAIN_ANCHORS_PER_IMAGE = 256
+    
+    # ROIs kept after tf.nn.top_k and before non-maximum suppression
+    PRE_NMS_LIMIT = 6000
 
     # ROIs kept after non-maximum suppression (training and inference)
     POST_NMS_ROIS_TRAINING = 2000

--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -284,7 +284,7 @@ class ProposalLayer(KE.Layer):
 
         # Improve performance by trimming to top anchors by score
         # and doing the rest on the smaller subset.
-        pre_nms_limit = tf.minimum(6000, tf.shape(anchors)[1])
+        pre_nms_limit = tf.minimum(self.config.PRE_NMS_LIMIT, tf.shape(anchors)[1])
         ix = tf.nn.top_k(scores, pre_nms_limit, sorted=True,
                          name="top_anchors").indices
         scores = utils.batch_slice([scores, ix], lambda x, y: tf.gather(x, y),


### PR DESCRIPTION
The pre_nms_limit(which is the count of ROIs kept after tf.nn.top_k) in model.py is hardcoded as 6000. This PR makes it configurable.