### PR TITLE
Made compatible to new version of VIA JSON format

### DIFF
--- a/samples/balloon/balloon.py
+++ b/samples/balloon/balloon.py
@@ -120,7 +120,10 @@ class BalloonDataset(utils.Dataset):
             # Get the x, y coordinaets of points of the polygons that make up
             # the outline of each object instance. There are stores in the
             # shape_attributes (see json format above)
-            polygons = [r['shape_attributes'] for r in a['regions'].values()]
+            if type(a['regions']) is dict:
+                polygons = [r['shape_attributes'] for r in a['regions'].values()]
+            else:
+                polygons = [r['shape_attributes'] for r in a['regions']] 
 
             # load_mask() needs the image size to convert polygons to masks.
             # Unfortunately, VIA doesn't include it in JSON, so we must read


### PR DESCRIPTION
VIA has changed JSON formatting in later versions. Now instead of a dictionary, "regions" has a list, see the issue #928