### PR TITLE
Add docker environment

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,0 +1,25 @@
+# Mask RCNN Docker Environment
+
+There are supported both, **CPU** and **GPU** versions.
+To run **GPU** the **nvidia-docker 2** has to be installed.
+
+## How to
+
+1. Clone the repository
+    ~~~git
+    git clone https://github.com/matterport/Mask_RCNN.git
+    ~~~
+
+1. **CPU version** run `docker-compose`
+
+    ~~~bash
+    cd docker
+    docker-compose run --rm --service-ports bash
+    ~~~
+
+1. **GPU version** run `docker-compose`
+
+    ~~~bash
+    cd docker
+    docker-compose run --rm --service-ports bash-gpu
+    ~~~

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -1,0 +1,24 @@
+FROM tensorflow/tensorflow:latest-py3
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxtst6 \
+    libfontconfig1 \
+    libxrender1 \
+    libsm6 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app/env && \
+    echo '#!/bin/bash\npip install -e . \nexec "$@"' > /app/env/entrypoint.bash && \
+    chmod +x /app/env/entrypoint.bash
+
+ADD docker/requirements.txt /app/env/requirements.txt
+
+RUN pip install cython && pip install -r /app/env/requirements.txt
+
+WORKDIR /app/src
+
+CMD [ "bash" ]
+ENTRYPOINT [ "bash", "/app/env/entrypoint.bash" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '2.3'
+
+services:
+  bash:
+    build:
+      context: ../.
+      dockerfile: ./docker/cpu/Dockerfile
+      network: host
+    image: mask-rcnn-cpu
+    command: bash
+    volumes:
+      - '../.:/app/src'
+    network_mode: host
+    ports: ["${TBPORT:-6006}:${TBPORT:-6006}", "${JNPORT:-8888}:${JNPORT:-8888}"]
+
+  bash-gpu:
+    build:
+      context: ../.
+      dockerfile: ./docker/gpu/Dockerfile
+      network: host
+    image: mask-rcnn-gpu
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+    command: bash  
+    volumes:
+      - '../.:/app/src'
+    network_mode: host
+    ports: ["${TBPORT:-6006}:${TBPORT:-6006}", "${JNPORT:-8888}:${JNPORT:-8888}"]

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -1,0 +1,24 @@
+FROM tensorflow/tensorflow:latest-gpu-py3
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxtst6 \
+    libfontconfig1 \
+    libxrender1 \
+    libsm6 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app/env && \
+    echo '#!/bin/bash\npip install -e . \nexec "$@"' > /app/env/entrypoint.bash && \
+    chmod +x /app/env/entrypoint.bash
+
+ADD docker/requirements.txt /app/env/requirements.txt
+
+RUN pip install cython && pip install -r /app/env/requirements.txt
+
+WORKDIR /app/src
+
+CMD [ "bash" ]
+ENTRYPOINT [ "bash", "/app/env/entrypoint.bash" ]

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,5 @@
+scikit-image
+opencv-contrib-python
+h5py
+imgaug
+pycocotools


### PR DESCRIPTION
This commit provides CPU and GPU docker environments to run the example jupyter notebooks in.
The directory the repository is cloned to is mounted in the docker container in /app/src.
The ```maskrcnn``` package is installed in editable mode ```pip install -e .```, so the code changes are propagated into the docker container.