### PR TITLE
Fix #551

### DIFF
--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -694,7 +694,7 @@ def compute_matches(gt_boxes, gt_class_ids, gt_masks,
         # 3. Find the match
         for j in sorted_ixs:
             # If ground truth box is already matched, go to next one
-            if gt_match[j] > 0:
+            if gt_match[j] > -1:
                 continue
             # If we reach IoU smaller than the threshold, end the loop
             iou = overlaps[i, j]


### PR DESCRIPTION
Valid index 0 is not regarded, leading to possibly more prediction_matches than grountruh_matches and recall values higher than 1.