### PR TITLE
[Bug fix]compute_overlaps_masks cannot filter empty masks

### DIFF
--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -102,8 +102,8 @@ def compute_overlaps_masks(masks1, masks2):
     """
     
     # If either set of masks is empty return empty result
-    if masks1.shape[0] == 0 or masks2.shape[0] == 0:
-        return np.zeros((masks1.shape[0], masks2.shape[-1]))
+    if masks1.shape[-1] == 0 or masks2.shape[-1] == 0:
+        return np.zeros((masks1.shape[-1], masks2.shape[-1]))
     # flatten masks and compute their areas
     masks1 = np.reshape(masks1 > .5, (-1, masks1.shape[-1])).astype(np.float32)
     masks2 = np.reshape(masks2 > .5, (-1, masks2.shape[-1])).astype(np.float32)


### PR DESCRIPTION
In compute_overlaps_masks(), the code checking the shape of masks1 and masks2 is not correct.
1. It should check masks's last dimension instead of first dimension to determine whether it's empty or not
2. When masks1 or masks2 is empty, it should return a zero array of shape (masks1.shape[-1], masks2.shape[-1])