### PR TITLE
[Bug fix] tf.boolean_mask cannot accept name=None

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2812,7 +2812,7 @@ def unmold_image(normalized_images, config):
 #  Miscellenous Graph Functions
 ############################################################
 
-def trim_zeros_graph(boxes, name=None):
+def trim_zeros_graph(boxes, name='trim_zeros'):
     """Often boxes are represented with matrices of shape [N, 4] and
     are padded with zeros. This removes zero boxes.
 


### PR DESCRIPTION
pass `name=None` to `tf.boolean_mask` will lead to `ValueError: At least one of name (None) and default_name (None) must be provided`.