### PR TITLE
only save best checkpoint

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2274,7 +2274,8 @@ class MaskRCNN():
             "*epoch*", "{epoch:04d}")
 
     def train(self, train_dataset, val_dataset, learning_rate, epochs, layers,
-              augmentation=None, custom_callbacks=None, no_augmentation_sources=None):
+              augmentation=None, custom_callbacks=None, no_augmentation_sources=None,
+              save_best_only=False, monitored_quantity='val_loss'):
         """Train the model.
         train_dataset, val_dataset: Training and validation Dataset objects.
         learning_rate: The learning rate to train with
@@ -2306,6 +2307,9 @@ class MaskRCNN():
         no_augmentation_sources: Optional. List of sources to exclude for
             augmentation. A source is string that identifies a dataset and is
             defined in the Dataset class.
+        save_best_only: Optional. If true, the latest best model 
+            according to the quantity monitored (monitored_quantity) will not be overwritten.
+        monitored_quantity: Optional. quantity to monitor (e.q: 'val_acc', 'val_loss')
         """
         assert self.mode == "training", "Create model in training mode."
 
@@ -2340,7 +2344,8 @@ class MaskRCNN():
             keras.callbacks.TensorBoard(log_dir=self.log_dir,
                                         histogram_freq=0, write_graph=True, write_images=False),
             keras.callbacks.ModelCheckpoint(self.checkpoint_path,
-                                            verbose=0, save_weights_only=True),
+                                            verbose=0, save_weights_only=True,
+                                            save_best_only=save_best_only, monitor=monitored_quantity),
         ]
 
         # Add custom callbacks to the list

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.16
 scipy
 Pillow
 cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 Pillow
 cython
 matplotlib==3.0.3
-scikit-image
+scikit-image<0.15
 tensorflow>=1.3.0
 keras>=2.0.8
 opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 Pillow
 cython
-matplotlib
+matplotlib==3.0.3
 scikit-image
 tensorflow>=1.3.0
 keras>=2.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<1.16
+numpy==1.15.4
 scipy
 Pillow
 cython


### PR DESCRIPTION
I think it's a pretty common use case to only save the best checkpoint (to save disk space). This pull request adds two additional parameters (` save_best_only` and `monitored_quantity`) to the `train` method. Both parameters default to the default values of the `ModelCheckpoint` method (see https://github.com/keras-team/keras/blob/master/keras/callbacks.py#L360). So this changeset shouldn't change the behavior of existing setups.

see also #1064 