### PR TITLE
[Bug fix]: predict error on multi-gpu

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -817,7 +817,7 @@ class DetectionLayer(KE.Layer):
         # normalized coordinates
         return tf.reshape(
             detections_batch,
-            [self.config.BATCH_SIZE, self.config.DETECTION_MAX_INSTANCES, 6])
+            [self.config.IMAGES_PER_GPU, self.config.DETECTION_MAX_INSTANCES, 6])
 
     def compute_output_shape(self, input_shape):
         return (None, self.config.DETECTION_MAX_INSTANCES, 6)


### PR DESCRIPTION
Predict problem on multi gpu (Input to reshape is a tensor with 24000 values, but the requested has 48000) 

I thought  this issue, see also:( [#1044](https://github.com/matterport/Mask_RCNN/issues/1044) )caused by `DetectionLayer output reshape`

[https://github.com/matterport/Mask_RCNN/blob/master/mrcnn/model.py#L820](https://github.com/matterport/Mask_RCNN/blob/master/mrcnn/model.py#L820)
```
 return tf.reshape(
            detections_batch,
            [self.config.BATCH_SIZE, self.config.DETECTION_MAX_INSTANCES, 6])
```
was called before `parallel_model  merge` at the `detection func`
[https://github.com/matterport/Mask_RCNN/blob/master/mrcnn/model.py#L2043](https://github.com/matterport/Mask_RCNN/blob/master/mrcnn/model.py#L2043)

so I think, the `DetectionLayer output reshape`  was error, and it should be changed like that,
```
 return tf.reshape(
            detections_batch,
            [self.config.IMAGES_PER_GPU, self.config.DETECTION_MAX_INSTANCES, 6])
```
it worked for me on mulit-gpu(two)