### PR TITLE
add warning to load_mask of dataset class

### DIFF
--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -378,6 +378,7 @@ class Dataset(object):
         """
         # Override this function to load a mask from your dataset.
         # Otherwise, it returns an empty mask.
+        print("You are using the default load_mask(), maybe you need to define your own one.")
         mask = np.empty([0, 0, 0])
         class_ids = np.empty([0], np.int32)
         return mask, class_ids


### PR DESCRIPTION
I spent a lot of time there days to deal with a weird situation that my training process only loads the image and the masks can't be loaded. Finally I founded that I misspelled the load_mask() to load_masks(). In the beginning I didn't consider the possibility because I thought if the function name was mispelled, the program may give an error of the function is not found or something like that. But apparently according to the default definition of load_mask(), the program may not give any warning. So it may be better to be some warning in the default load_mask() to help people to knows what's going on.