### PR TITLE
[Bug fix] image shape checking fails in Python2

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1847,7 +1847,7 @@ class MaskRCNN():
 
         # Image size must be dividable by 2 multiple times
         h, w = config.IMAGE_SHAPE[:2]
-        if h / 2**6 != int(h / 2**6) or w / 2**6 != int(w / 2**6):
+        if h % (2**6) != 0 or w % (2**6) != 0:
             raise Exception("Image size must be dividable by 2 at least 6 times "
                             "to avoid fractions when downscaling and upscaling."
                             "For example, use 256, 320, 384, 448, 512, ... etc. ")


### PR DESCRIPTION
image shape checking fails in Python2.
Ref: https://github.com/matterport/Mask_RCNN/issues/992