### PR TITLE
Configurable mask branch

### DIFF
--- a/mrcnn/config.py
+++ b/mrcnn/config.py
@@ -226,6 +226,14 @@ class Config(object):
         # Image meta data length
         # See compose_image_meta() for details
         self.IMAGE_META_SIZE = 1 + 3 + 3 + 4 + 1 + self.NUM_CLASSES
+        
+        # Number of Conv2DTranspose layers in build_fpn_mask_graph
+        assert self.MASK_SHAPE[0] == self.MASK_SHAPE[1], "Only support square mask currently!"
+        num_deconv_layers = np.log2(self.MASK_SHAPE[0] / self.MASK_POOL_SIZE)
+        # make sure num_deconv_layers is a positive integer
+        assert num_deconv_layers == int(num_deconv_layers) and num_deconv_layers >= 1, \
+            "MASK_SHAPE[0] should be MASK_POOL_SIZE*(2**n), where n>=1"
+        self.NUM_DECONV_LAYERS = int(num_deconv_layers)
 
     def display(self):
         """Display Configuration values."""

--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -955,7 +955,7 @@ def fpn_classifier_graph(rois, feature_maps, image_meta,
 
 
 def build_fpn_mask_graph(rois, feature_maps, image_meta,
-                         pool_size, num_classes, train_bn=True):
+                         pool_size, num_classes, num_deconv_layers, train_bn=True):
     """Builds the computation graph of the mask head of Feature Pyramid Network.
 
     rois: [batch, num_rois, (y1, x1, y2, x2)] Proposal boxes in normalized
@@ -965,9 +965,10 @@ def build_fpn_mask_graph(rois, feature_maps, image_meta,
     image_meta: [batch, (meta data)] Image details. See compose_image_meta()
     pool_size: The width of the square feature map generated from ROI Pooling.
     num_classes: number of classes, which determines the depth of the results
+    num_deconv_layers: The number of Conv2DTranspose layers. 
     train_bn: Boolean. Train or freeze Batch Norm layers
 
-    Returns: Masks [batch, num_rois, MASK_POOL_SIZE, MASK_POOL_SIZE, NUM_CLASSES]
+    Returns: Masks [batch, num_rois, MASK_SHAPE[0], MASK_SHAPE[1], NUM_CLASSES]
     """
     # ROI Pooling
     # Shape: [batch, num_rois, MASK_POOL_SIZE, MASK_POOL_SIZE, channels]
@@ -999,8 +1000,10 @@ def build_fpn_mask_graph(rois, feature_maps, image_meta,
                            name='mrcnn_mask_bn4')(x, training=train_bn)
     x = KL.Activation('relu')(x)
 
-    x = KL.TimeDistributed(KL.Conv2DTranspose(256, (2, 2), strides=2, activation="relu"),
-                           name="mrcnn_mask_deconv")(x)
+    for i in range(num_deconv_layers):
+        x = KL.TimeDistributed(KL.Conv2DTranspose(256, (2, 2), strides=2, activation="relu"),
+                           name="mrcnn_mask_deconv_" + str(i+1))(x)
+    
     x = KL.TimeDistributed(KL.Conv2D(num_classes, (1, 1), strides=1, activation="sigmoid"),
                            name="mrcnn_mask")(x)
     return x
@@ -2002,6 +2005,7 @@ class MaskRCNN():
                                               input_image_meta,
                                               config.MASK_POOL_SIZE,
                                               config.NUM_CLASSES,
+                                              config.NUM_DECONV_LAYERS,
                                               train_bn=config.TRAIN_BN)
 
             # TODO: clean up (use tf.identify if necessary)
@@ -2050,6 +2054,7 @@ class MaskRCNN():
                                               input_image_meta,
                                               config.MASK_POOL_SIZE,
                                               config.NUM_CLASSES,
+                                              config.NUM_DECONV_LAYERS,
                                               train_bn=config.TRAIN_BN)
 
             model = KM.Model([input_image, input_image_meta, input_anchors],


### PR DESCRIPTION
This PR makes MASK_SHAPE configurable, and the structure of mask branch will be adjusted accordingly. 
It also adds assertion for easier debugging, ref: https://github.com/matterport/Mask_RCNN/issues/331.

One can now set MASK_SHAPE as [28,28], [56,56], [112, 112], [224, 224], etc, given MASK_POOL_SIZE is 14.