### PR TITLE
fix mrcnn_bbox_loss

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1137,7 +1137,7 @@ def mrcnn_bbox_loss_graph(target_bbox, target_class_ids, pred_bbox):
     loss = K.switch(tf.size(target_bbox) > 0,
                     smooth_l1_loss(y_true=target_bbox, y_pred=pred_bbox),
                     tf.constant(0.0))
-    loss = K.mean(loss)
+    loss = K.mean(K.sum(loss, axis=1))
     return loss
 
 

--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1137,7 +1137,7 @@ def mrcnn_bbox_loss_graph(target_bbox, target_class_ids, pred_bbox):
     loss = K.switch(tf.size(target_bbox) > 0,
                     smooth_l1_loss(y_true=target_bbox, y_pred=pred_bbox),
                     tf.constant(0.0))
-    loss = K.mean(K.sum(loss, axis=1))
+    loss = K.sum(loss)/K.int_shape(target_class_ids)[0]
     return loss
 
 


### PR DESCRIPTION
According to https://github.com/matterport/Mask_RCNN/issues/786 and the paper of Fast R-CNN, L_loc should be the sum of smooth_l1_loss of its four items.