### PR TITLE
Fix the 'calling Model.__init__() first' issue to train the model on multiple GPUs

### DIFF
--- a/mrcnn/parallel_model.py
+++ b/mrcnn/parallel_model.py
@@ -32,11 +32,11 @@ class ParallelModel(KM.Model):
         keras_model: The Keras model to parallelize
         gpu_count: Number of GPUs. Must be > 1
         """
+        merged_outputs = self.make_parallel(keras_model, gpu_count)
+        super(ParallelModel, self).__init__(inputs=keras_model.inputs,
+                                            outputs=merged_outputs)
         self.inner_model = keras_model
         self.gpu_count = gpu_count
-        merged_outputs = self.make_parallel()
-        super(ParallelModel, self).__init__(inputs=self.inner_model.inputs,
-                                            outputs=merged_outputs)
 
     def __getattribute__(self, attrname):
         """Redirect loading and saving methods to the inner model. That's where
@@ -51,34 +51,34 @@ class ParallelModel(KM.Model):
         super(ParallelModel, self).summary(*args, **kwargs)
         self.inner_model.summary(*args, **kwargs)
 
-    def make_parallel(self):
+    def make_parallel(self, inner_model, gpu_count):
         """Creates a new wrapper model that consists of multiple replicas of
         the original model placed on different GPUs.
         """
         # Slice inputs. Slice inputs on the CPU to avoid sending a copy
         # of the full inputs to all GPUs. Saves on bandwidth and memory.
-        input_slices = {name: tf.split(x, self.gpu_count)
-                        for name, x in zip(self.inner_model.input_names,
-                                           self.inner_model.inputs)}
+        input_slices = {name: tf.split(x, gpu_count)
+                        for name, x in zip(inner_model.input_names,
+                                           inner_model.inputs)}
 
-        output_names = self.inner_model.output_names
+        output_names = inner_model.output_names
         outputs_all = []
-        for i in range(len(self.inner_model.outputs)):
+        for i in range(len(inner_model.outputs)):
             outputs_all.append([])
 
         # Run the model call() on each GPU to place the ops there
-        for i in range(self.gpu_count):
+        for i in range(gpu_count):
             with tf.device('/gpu:%d' % i):
                 with tf.name_scope('tower_%d' % i):
                     # Run a slice of inputs through this replica
-                    zipped_inputs = zip(self.inner_model.input_names,
-                                        self.inner_model.inputs)
+                    zipped_inputs = zip(inner_model.input_names,
+                                        inner_model.inputs)
                     inputs = [
                         KL.Lambda(lambda s: input_slices[name][i],
                                   output_shape=lambda s: (None,) + s[1:])(tensor)
                         for name, tensor in zipped_inputs]
                     # Create the model replica and get the outputs
-                    outputs = self.inner_model(inputs)
+                    outputs = inner_model(inputs)
                     if not isinstance(outputs, list):
                         outputs = [outputs]
                     # Save the outputs for merging back together later
@@ -141,7 +141,7 @@ if __name__ == "__main__":
         x = KL.Dense(128, activation='relu', name="dense1")(x)
         x = KL.Dense(num_classes, activation='softmax', name="dense2")(x)
 
-        return KM.Model(inputs, x, "digit_classifier_model")
+        return KM.Model(inputs=inputs, outputs=x, name="digit_classifier_model")
 
     # Load MNIST Data
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
@@ -154,6 +154,9 @@ if __name__ == "__main__":
     # Build data generator and model
     datagen = ImageDataGenerator()
     model = build_model(x_train, 10)
+    optimizer = keras.optimizers.SGD(lr=0.01, momentum=0.9, clipnorm=5.0)
+    model.compile(loss='sparse_categorical_crossentropy',
+                  optimizer=optimizer, metrics=['accuracy'])
 
     # Add multi-GPU support.
     model = ParallelModel(model, GPU_COUNT)


### PR DESCRIPTION
Hi there,

This PR fixes the 'calling Model.__ init __ () first' issue to train the model on multiple GPUs. Tested on Keras 2.2.4.
Specifically, when I ran:

_python Mask_RCNN/mrcnn/parallel_model.py_

I got the following errors:

Using TensorFlow backend.
x_train shape: (60000, 28, 28, 1)
x_test shape: (10000, 28, 28, 1)
Traceback (most recent call last):
  File "/home/myenv/lib/python3.6/site-packages/keras/engine/network.py", line 307, in __setattr__
    is_graph_network = self._is_graph_network
  File "Mask_RCNN/mrcnn/parallel_model.py", line 46, in __getattribute__
    return super(ParallelModel, self).__getattribute__(attrname)
AttributeError: 'ParallelModel' object has no attribute '_is_graph_network'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "Mask_RCNN/mrcnn/parallel_model.py", line 159, in <module>
    model = ParallelModel(model, GPU_COUNT)
  File "Mask_RCNN/mrcnn/parallel_model.py", line 35, in __init__
    self.inner_model = keras_model
  File "/home/myenv/lib/python3.6/site-packages/keras/engine/network.py", line 310, in __setattr__
    'It looks like you are subclassing `Model` and you '
RuntimeError: It looks like you are subclassing `Model` and you forgot to call `super(YourClass, self).__init__()`. Always start with this line.