### PR TITLE
Reversed order (1) and (2) in installation; Fixes #1255

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ If you use Docker, the code has been verified to work on
 
 
 ## Installation
-1. Install dependencies
+1. Clone this repository
+2. Install dependencies
    ```bash
    pip3 install -r requirements.txt
    ```
-2. Clone this repository
 3. Run setup from the repository root directory
     ```bash
     python3 setup.py install


### PR DESCRIPTION
Minor  fix. Reference to #1255, order has been made to clone first then use `pip install`