### PR TITLE
Fix Bug in compute_matches

### DIFF
--- a/mrcnn/utils.py
+++ b/mrcnn/utils.py
@@ -671,12 +671,6 @@ def compute_matches(gt_boxes, gt_class_ids, gt_masks,
     gt_masks = gt_masks[..., :gt_boxes.shape[0]]
     pred_boxes = trim_zeros(pred_boxes)
     pred_scores = pred_scores[:pred_boxes.shape[0]]
-    # Sort predictions by score from high to low
-    indices = np.argsort(pred_scores)[::-1]
-    pred_boxes = pred_boxes[indices]
-    pred_class_ids = pred_class_ids[indices]
-    pred_scores = pred_scores[indices]
-    pred_masks = pred_masks[..., indices]
 
     # Compute IoU overlaps [pred_masks, gt_masks]
     overlaps = compute_overlaps_masks(pred_masks, gt_masks)


### PR DESCRIPTION
Fix issue #1422. Removed the sorting in ```compute_matches(..)```

Predictions are already sorted in the DetectionLayer. 

If there are two or more detections with the same score,  ```np.argsort(pred_scores)[::-1] ``` gives a different sorting.

For example, if ```x = [0.99,0.99,0.99]```, then: ```np.argsort(x)[::-1] = [2,1,0]```

The order of ```pred_masks``` is changed and the output ```pred_match``` computes matches for the **changed array**(!), and not for the original array. We do not return the changed ```pred_masks```. Therefore, the returned matching is wrong.