### PR TITLE
Add Rot90 to possible mask augmentations

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1237,7 +1237,7 @@ def load_image_gt(dataset, config, image_id, augment=False, augmentation=None,
         # test your augmentation on masks
         MASK_AUGMENTERS = ["Sequential", "SomeOf", "OneOf", "Sometimes",
                            "Fliplr", "Flipud", "CropAndPad",
-                           "Affine", "PiecewiseAffine"]
+                           "Affine", "PiecewiseAffine", "Rot90"]
 
         def hook(images, augmenter, parents, default):
             """Determines which augmenters to apply to masks."""


### PR DESCRIPTION
At the moment, if Rot90 augmentation is used from imgaug library, the mask will remain unchanged. This commit adds Rot90 to the list of augmentations to apply to masks as well.