### PR TITLE
ommit redundant bias in identity and conv_blocks

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -93,7 +93,7 @@ def compute_backbone_shapes(config, image_shape):
 # https://github.com/fchollet/deep-learning-models/blob/master/resnet50.py
 
 def identity_block(input_tensor, kernel_size, filters, stage, block,
-                   use_bias=True, train_bn=True):
+                   use_bias=False, train_bn=True):
     """The identity_block is the block that has no conv layer at shortcut
     # Arguments
         input_tensor: input tensor
@@ -128,7 +128,7 @@ def identity_block(input_tensor, kernel_size, filters, stage, block,
 
 
 def conv_block(input_tensor, kernel_size, filters, stage, block,
-               strides=(2, 2), use_bias=True, train_bn=True):
+               strides=(2, 2), use_bias=False, train_bn=True):
     """conv_block is the block that has a conv layer at shortcut
     # Arguments
         input_tensor: input tensor


### PR DESCRIPTION
I believe that the parameter `use_bias` in `identity_block` and `conv_block` should be set to `False` by default. Bias in convolutional layers followed by batch normalization layers are redundant / ignored parameters as written in [1], therefore they just gives us extra parameters to be trained but not used. 

[1] [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/pdf/1502.03167.pdf)