### PR TITLE
Fix problem of identical data produced by data generators

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -1685,6 +1685,12 @@ def data_generator(dataset, config, shuffle=True, augment=False, augmentation=No
                                              config.BACKBONE_STRIDES,
                                              config.RPN_ANCHOR_STRIDE)
 
+    #set random seed unique to worker 
+    pid = multiprocessing.current_process()._identity[0]
+    np.random.seed(pid)
+    random.seed(pid)
+
+
     # Keras requires a generator to run indefinitely.
     while True:
         try:


### PR DESCRIPTION
As mentioned in #1511 , it seems to me that the data generator workers shuffle data in exactly the same way.
Setting a new random seed, based on the process ID, in the data generator function could fix this issue.