### PR TITLE
Add shape argument to sklearn.draw.polygon

### DIFF
--- a/samples/balloon/balloon.py
+++ b/samples/balloon/balloon.py
@@ -160,7 +160,8 @@ class BalloonDataset(utils.Dataset):
                         dtype=np.uint8)
         for i, p in enumerate(info["polygons"]):
             # Get indexes of pixels inside the polygon and set them to 1
-            rr, cc = skimage.draw.polygon(p['all_points_y'], p['all_points_x'])
+            rr, cc = skimage.draw.polygon(p['all_points_y'], p['all_points_x'], 
+                                          shape = (info["height"], info["width"]))
             mask[rr, cc, i] = 1
 
         # Return mask, and array of class IDs of each instance. Since we have


### PR DESCRIPTION
In cases where the annotation polygons are placed outside the image, the shape argument in `skimage.draw.polygon` is required to ensure the image is drawn within the image ([documentation](https://scikit-image.org/docs/0.13.x/api/skimage.draw.html#skimage.draw.polygon)).  