### PR TITLE
Adds a link to let github visitors test Mask R-CNN from their browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It includes code to run object detection and instance segmentation on arbitrary 
 
 * [train_shapes.ipynb](samples/shapes/train_shapes.ipynb) shows how to train Mask R-CNN on your own dataset. This notebook introduces a toy dataset (Shapes) to demonstrate training on a new dataset.
 
-* ([model.py](mrcnn/model.py), [utils.py](mrcnn/utils.py), [config.py](mrcnn/config.py)): These files contain the main Mask RCNN implementation. 
+* ([model.py](mrcnn/model.py), [utils.py](mrcnn/utils.py), [config.py](mrcnn/config.py)): These files contain the main Mask RCNN implementation.
 
 
 * [inspect_data.ipynb](samples/coco/inspect_data.ipynb). This notebook visualizes the different pre-processing steps
@@ -36,7 +36,7 @@ This notebooks inspects the weights of a trained model and looks for anomalies a
 
 
 # Step by Step Detection
-To help with debugging and understanding the model, there are 3 notebooks 
+To help with debugging and understanding the model, there are 3 notebooks
 ([inspect_data.ipynb](samples/coco/inspect_data.ipynb), [inspect_model.ipynb](samples/coco/inspect_model.ipynb),
 [inspect_weights.ipynb](samples/coco/inspect_weights.ipynb)) that provide a lot of visualizations and allow running the model step by step to inspect the output at each point. Here are a few examples:
 
@@ -116,11 +116,11 @@ In summary, to train the model on your own dataset you'll need to extend two cla
 This class contains the default configuration. Subclass it and modify the attributes you need to change.
 
 ```Dataset```
-This class provides a consistent way to work with any dataset. 
-It allows you to use new datasets for training without having to change 
+This class provides a consistent way to work with any dataset.
+It allows you to use new datasets for training without having to change
 the code of the model. It also supports loading multiple datasets at the
-same time, which is useful if the objects you want to detect are not 
-all available in one dataset. 
+same time, which is useful if the objects you want to detect are not
+all available in one dataset.
 
 See examples in `samples/shapes/train_shapes.ipynb`, `samples/coco/coco.py`, `samples/balloon/balloon.py`, and `samples/nucleus/nucleus.py`.
 
@@ -131,12 +131,12 @@ This implementation follows the Mask RCNN paper for the most part, but there are
 * **Bounding Boxes**: Some datasets provide bounding boxes and some provide masks only. To support training on multiple datasets we opted to ignore the bounding boxes that come with the dataset and generate them on the fly instead. We pick the smallest box that encapsulates all the pixels of the mask as the bounding box. This simplifies the implementation and also makes it easy to apply image augmentations that would otherwise be harder to apply to bounding boxes, such as image rotation.
 
     To validate this approach, we compared our computed bounding boxes to those provided by the COCO dataset.
-We found that ~2% of bounding boxes differed by 1px or more, ~0.05% differed by 5px or more, 
+We found that ~2% of bounding boxes differed by 1px or more, ~0.05% differed by 5px or more,
 and only 0.01% differed by 10px or more.
 
 * **Learning Rate:** The paper uses a learning rate of 0.02, but we found that to be
 too high, and often causes the weights to explode, especially when using a small batch
-size. It might be related to differences between how Caffe and TensorFlow compute 
+size. It might be related to differences between how Caffe and TensorFlow compute
 gradients (sum vs mean across batches and GPUs). Or, maybe the official model uses gradient
 clipping to avoid this issue. We do use gradient clipping, but don't set it too aggressively.
 We found that smaller learning rates converge faster anyway so we go with that.
@@ -187,13 +187,18 @@ If you use Docker, the code has been verified to work on
 3. Run setup from the repository root directory
     ```bash
     python3 setup.py install
-    ``` 
+    ```
 3. Download pre-trained COCO weights (mask_rcnn_coco.h5) from the [releases page](https://github.com/matterport/Mask_RCNN/releases).
 4. (Optional) To train or test on MS COCO install `pycocotools` from one of these repos. They are forks of the original pycocotools with fixes for Python3 and Windows (the official repo doesn't seem to be active anymore).
 
     * Linux: https://github.com/waleedka/coco
     * Windows: https://github.com/philferriere/cocoapi.
     You must have the Visual C++ 2015 build tools on your path (see the repo for additional details)
+
+# Demonstration
+
+You can use this link to test Mask R-CNN directly in your browser, by uploading an image:
+https://elody.com/scenario/plan/17/
 
 # Projects Using this Model
 If you extend this model to other datasets or build projects that use it, we'd love to hear from you.


### PR DESCRIPTION
I have added a link to the README.md that will allow anyone to test Mask R-CNN directly in the browser.

Just try it out and you will see what I mean: https://elody.com/scenario/plan/17/

Is this useful for you?

I am building a website that can let anyone make their code available to endusers without download or installation.

I used Mask R-CNN as a test case, because it is popular on github and it's interesting to test Mask R-CNN with random images.

My goal is that developers will upload their existing github projects to elody.com and put the link to it on their github page, to make showcasing the projects more convenient. Elody can also do a whole lot more than that, but it's a good way to get started.

Do you like it?

Is there anything else you would like to see to make this more useful?

I would really appreciate any feedback!