### PR TITLE
Add upper bound for Tensorflow in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Pillow
 cython
 matplotlib
 scikit-image
-tensorflow>=1.3.0
+tensorflow>=1.3.0, <2.0
 keras>=2.0.8
 opencv-python
 h5py


### PR DESCRIPTION
- Tensorflow 2.0 is not compatible with demo.ipynb due to removal of log function, potentially among others
- Fixes https://github.com/matterport/Mask_RCNN/issues/1797