### PR TITLE
Change dependency to tensorflow-gpu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Pillow
 cython
 matplotlib
 scikit-image
-tensorflow>=1.3.0
+tensorflow-gpu>=1.3.0
 keras>=2.0.8
 opencv-python
 h5py


### PR DESCRIPTION
I noticed that running the balloon sample wasn't really using my GPU. Replacing tensorflow with tensorflow-gpu made things run much faster. I assume this would be the case for everyone and you already tell people that they need a GPU in the docs.