### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2356,7 +2356,7 @@ class MaskRCNN():
         # Work-around for Windows: Keras fails on Windows when using
         # multiprocessing workers. See discussion here:
         # https://github.com/matterport/Mask_RCNN/issues/13#issuecomment-353124009
-        if os.name is 'nt':
+        if os.name == 'nt':
             workers = 0
         else:
             workers = multiprocessing.cpu_count()


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% python3.8
```
>>> 'nt' is 'nt'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
>>> nt = 'n'
>>> nt += 't'
>>> nt == 'nt'
True
>>> nt is 'nt'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```