### PR TITLE
Update model.py

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -550,7 +550,7 @@ def detection_targets_graph(proposals, gt_class_ids, gt_boxes, gt_masks, config)
     # Positive ROIs
     positive_count = int(config.TRAIN_ROIS_PER_IMAGE *
                          config.ROI_POSITIVE_RATIO)
-    positive_indices = tf.random_shuffle(positive_indices)[:positive_count]
+    positive_indices = tf.random.shuffle(positive_indices)[:positive_count]
     positive_count = tf.shape(positive_indices)[0]
     # Negative ROIs. Add enough to maintain positive:negative ratio.
     r = 1.0 / config.ROI_POSITIVE_RATIO


### PR DESCRIPTION
Random shuffle has been changed to tf.random.shuffle in Tensorflow v2.1.0
https://www.tensorflow.org/api_docs/python/tf/random/shuffle