### PR TITLE
Add requirement library(pycocotools) into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ opencv-python
 h5py
 imgaug
 IPython[all]
+pycocotools


### PR DESCRIPTION
I tried to use Mask RCNN demo ipynb, however the source did not work correct. The reason of this was a requirement library pycocotools had not been installed. Therefore, I added pycocotools into requirements.txt.