### PR TITLE
Fix slice index out of bounds for batch_size >32 #817

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2521,7 +2521,7 @@ class MaskRCNN():
             log("anchors", anchors)
         # Run object detection
         detections, _, _, mrcnn_mask, _, _, _ =\
-            self.keras_model.predict([molded_images, image_metas, anchors], verbose=0)
+            self.keras_model.predict([molded_images, image_metas, anchors], batch_size=len(images), verbose=0)
         # Process detections
         results = []
         for i, image in enumerate(images):


### PR DESCRIPTION
The default **batch_size** for `keras_model.predict()` is 32 therefore the code will crash with a "InvalidArgumentError: slice index 33 of dimension 0 out of bounds" error if batch_size is more than that.

This fix is based on the issue https://github.com/matterport/Mask_RCNN/issues/817