### PR TITLE
Updated model.py to add metrics_tensors array initialization

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2162,7 +2162,8 @@ class MaskRCNN():
         # First, clear previously set losses to avoid duplication
         self.keras_model._losses = []
         self.keras_model._per_input_losses = {}
-        loss_names = [
+	self.keras_model.metrics_tensors = []
+	loss_names = [
             "rpn_class_loss",  "rpn_bbox_loss",
             "mrcnn_class_loss", "mrcnn_bbox_loss", "mrcnn_mask_loss"]
         for name in loss_names:


### PR DESCRIPTION
updated mrcnn/model.py. added `metrics_tensors` array initialization line to remove error: 'Model' does not have attribute 'metrics_tensors' on the line `self.keras_model.metrics_tensors.append(loss)`