### PR TITLE
fix(sec): upgrade tensorflow to 2.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Pillow
 cython
 matplotlib
 scikit-image
-tensorflow>=1.3.0
+tensorflow>=2.9.1
 keras>=2.0.8
 opencv-python
 h5py


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tensorflow 1.3.0
- [CVE-2022-21725](https://www.oscs1024.com/hd/CVE-2022-21725)


### What did I do？
Upgrade tensorflow from 1.3.0 to 2.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS