### PR TITLE
fix(sec): upgrade keras to 2.6.0rc3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cython
 matplotlib
 scikit-image
 tensorflow>=1.3.0
-keras>=2.0.8
+keras>=2.6.0rc3
 opencv-python
 h5py
 imgaug


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in keras 2.0.8
- [MPS-2022-14959](https://www.oscs1024.com/hd/MPS-2022-14959)


### What did I do？
Upgrade keras from 2.0.8 to 2.6.0rc3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS